### PR TITLE
Depend on Products.CMFPlone rather than Plone

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(name='souper.plone',
       zip_safe=False,
       install_requires=[
           'setuptools',
-          'Plone',
+          'Products.CMFPlone',
           'souper',
       ],
       extras_require={


### PR DESCRIPTION
This avoids pulling some extra distributions that are not needed at all.